### PR TITLE
GPII-3255

### DIFF
--- a/docs/utils.md
+++ b/docs/utils.md
@@ -23,9 +23,9 @@ This component requires the same CouchDB options as other components in this mod
 
 ### `{that}.createNewUser(userData)`
 
-* Take an object with `username`, `email`, and `password` entries.
-* Returns a promise containing either the new CouchDB record for the account or
-  an `error` property and message.
+* `userData` - Take an object with `username`, `email`, and `password` entries.
+* Returns:  A promise resolving with the new CouchDB user record on success, or
+  a promise rejecting with an `error` property and message on failure.
 
 Creates a new user in the system with a username, email, and password.
 
@@ -35,9 +35,12 @@ utils.createNewUser({username: "alice", email: "alice@gpii.org", password: "#1 C
 
 ### `{that}.verifyPassword(userRecord, password)`
 
-* Takes a full user record object as stored in CouchDB and checks to see if the
-  supplied password matches.
-* Returns true or false if the password matches.
+* `userRecord` - Takes a full user record object as stored in CouchDB and checks to see if the
+  supplied password matches. In general this should be a record retrieved from CouchDB and not
+  something you generate yourself. For reference, the `userRecord` structure can be seen in
+  this [test fixture](https://github.com/GPII/gpii-express-user/blob/a83beacdffb4096a379fe91a8f6e23979839fdd8/tests/data/users.json).
+* `password` - Password to verify against the userRecord.
+* Returns: `true` if the password matches, otherwise `false`.
 
 ```javascript
 var userRecord = couchDBStore.getUserRecordFromCouchForUsernameOrEmail("alice");
@@ -48,8 +51,10 @@ Returns a promise that will contain the user recored on a successful resolve.
 
 ### `{that}.unlockUser(username, password)`
 
-* Takes a username and password as strings.
-* Returns the `userData` record if the password is correct, otherwise an `isError` Object.
+* `username` - Username string to unlock.
+* `password` - Password string to use for unlocking `username`.
+* Returns a promise resolving with the `userData` record if the password is correct,
+  otherwise rejecting with an `isError` Object.
 
 ```javascript
 var userRecord = utils.unlockUser("alice", "#1 Cloudsafe!");

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -1,0 +1,25 @@
+# Utility Components and Methods API
+
+A number of useful routines for user management are available via a promise based API. These are useful for writing management and batch routines, building other HTTP interfaces and services on top of the system, and testing.
+
+## gpii.express.user.utils
+
+Component containing a number of useful utility methods. Detailed JSDocs for the 
+component and invokers are located in [utils.js](../src/js/server/utils.js).
+
+### createNewUser
+
+Creates a new user in the system with a username, email, and password.
+
+Returns a promise that will contain the new user record after successful creation.
+
+### verifyPassword
+
+Takes a full user record object as stored in CouchDB and checks to see if the supplied password matches.
+
+Returns a promise that will contain the user recored on a successful resolve.
+
+### unlockUser
+
+Takes a username and password and returns True if they match.
+

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -4,12 +4,12 @@ A number of useful routines for user management are available via a promise base
 These are useful for writing management and batch routines, building other HTTP interfaces
 and services on top of the system, and testing.
 
-# `gpii.express.user.utils`
+## `gpii.express.user.utils`
 
 Component containing a number of useful utility methods. Detailed JSDocs for the
 component and invokers are located in [utils.js](../src/js/server/utils.js).
 
-## Component Options
+### Component Options
 
 This component requires the same CouchDB options as other components in this module.
 
@@ -19,9 +19,9 @@ This component requires the same CouchDB options as other components in this mod
 | `couch.userDbName` | `{String}` | The CouchDB database name containing our user records.  Defaults to `users`. |
 | `couch.userDbUrl`  | `{String}` | The URL of our CouchDB instance.  By default this is expanded from `userDbName` above using the pattern `http://admin:admin@localhost:%port/%userDbName` (see above). |
 
-## Component Invokers
+### Component Invokers
 
-## `{that}.createNewUser(userData)`
+### `{that}.createNewUser(userData)`
 
 * Take an object with `username`, `email`, and `password` entries.
 * Returns a promise containing either the new CouchDB record for the account or
@@ -33,7 +33,7 @@ Creates a new user in the system with a username, email, and password.
 utils.createNewUser({username: "alice", email: "alice@gpii.org", password: "#1 Cloudsafe!"});
 ```
 
-## `{that}.verifyPassword(userRecord, password)`
+### `{that}.verifyPassword(userRecord, password)`
 
 * Takes a full user record object as stored in CouchDB and checks to see if the
   supplied password matches.
@@ -46,7 +46,7 @@ utils.verifyPassword(userRecord, "#1 CloudSafe!"); // true if this is their pass
 
 Returns a promise that will contain the user recored on a successful resolve.
 
-## `{that}.unlockUser(username, password)
+### `{that}.unlockUser(username, password)`
 
 * Takes a username and password as strings.
 * Returns the `userData` record if the password is correct, otherwise an `isError` Object.

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -1,25 +1,57 @@
 # Utility Components and Methods API
 
-A number of useful routines for user management are available via a promise based API. These are useful for writing management and batch routines, building other HTTP interfaces and services on top of the system, and testing.
+A number of useful routines for user management are available via a promise based API.
+These are useful for writing management and batch routines, building other HTTP interfaces
+and services on top of the system, and testing.
 
-## gpii.express.user.utils
+# `gpii.express.user.utils`
 
-Component containing a number of useful utility methods. Detailed JSDocs for the 
+Component containing a number of useful utility methods. Detailed JSDocs for the
 component and invokers are located in [utils.js](../src/js/server/utils.js).
 
-### createNewUser
+## Component Options
+
+This component requires the same CouchDB options as other components in this module.
+
+| Option             | Type       | Description |
+| ------------------ | ---------- | ----------- |
+| `couch.port`       | `{String}` | The port on which our CouchDB instance runs. |
+| `couch.userDbName` | `{String}` | The CouchDB database name containing our user records.  Defaults to `users`. |
+| `couch.userDbUrl`  | `{String}` | The URL of our CouchDB instance.  By default this is expanded from `userDbName` above using the pattern `http://admin:admin@localhost:%port/%userDbName` (see above). |
+
+## Component Invokers
+
+## `{that}.createNewUser(userData)`
+
+* Take an object with `username`, `email`, and `password` entries.
+* Returns a promise containing either the new CouchDB record for the account or
+  an `error` property and message.
 
 Creates a new user in the system with a username, email, and password.
 
-Returns a promise that will contain the new user record after successful creation.
+```javascript
+utils.createNewUser({username: "alice", email: "alice@gpii.org", password: "#1 Cloudsafe!"});
+```
 
-### verifyPassword
+## `{that}.verifyPassword(userRecord, password)`
 
-Takes a full user record object as stored in CouchDB and checks to see if the supplied password matches.
+* Takes a full user record object as stored in CouchDB and checks to see if the
+  supplied password matches.
+* Returns true or false if the password matches.
+
+```javascript
+var userRecord = couchDBStore.getUserRecordFromCouchForUsernameOrEmail("alice");
+utils.verifyPassword(userRecord, "#1 CloudSafe!"); // true if this is their password
+```
 
 Returns a promise that will contain the user recored on a successful resolve.
 
-### unlockUser
+## `{that}.unlockUser(username, password)
 
-Takes a username and password and returns True if they match.
+* Takes a username and password as strings.
+* Returns the `userData` record if the password is correct, otherwise an `isError` Object.
 
+```javascript
+var userRecord = utils.unlockUser("alice", "#1 Cloudsafe!");
+// userRecord is their full internal record from CouchDB
+```

--- a/src/js/server/api.js
+++ b/src/js/server/api.js
@@ -10,7 +10,6 @@
 /* eslint-env node */
 "use strict";
 var fluid = require("infusion");
-var request = require("request"); // TODO:  Replace this with a writable data source.
 
 require("gpii-express");
 require("./current.js");
@@ -23,7 +22,6 @@ require("./signup.js");
 require("./verify.js");
 require("./utils.js");
 
-var gpii = fluid.registerNamespace("gpii");
 fluid.registerNamespace("gpii.express.user.api");
 
 fluid.defaults("gpii.express.user.api", {

--- a/src/js/server/api.js
+++ b/src/js/server/api.js
@@ -10,6 +10,7 @@
 /* eslint-env node */
 "use strict";
 var fluid = require("infusion");
+var request = require("request"); // TODO:  Replace this with a writable data source.
 
 require("gpii-express");
 require("./current.js");
@@ -20,7 +21,9 @@ require("./logout.js");
 require("./reset.js");
 require("./signup.js");
 require("./verify.js");
+require("./utils.js");
 
+var gpii = fluid.registerNamespace("gpii");
 fluid.registerNamespace("gpii.express.user.api");
 
 fluid.defaults("gpii.express.user.api", {
@@ -56,6 +59,10 @@ fluid.defaults("gpii.express.user.api", {
             "target": "{that gpii.express.router}.options.couch"
         },
         {
+            "source": "{that}.options.couch",
+            "target": "{that gpii.express.user.utils}.options.couch"
+        },
+        {
             source: "{that}.options.app",
             target: "{that gpii.express.router}.options.app"
         },
@@ -65,6 +72,9 @@ fluid.defaults("gpii.express.user.api", {
         }
     ],
     components: {
+        utils: {
+            type:     "gpii.express.user.utils"
+        },
         // API Endpoints (routers)
         current: {
             type:     "gpii.express.user.current",
@@ -131,6 +141,7 @@ fluid.defaults("gpii.express.user.api", {
         }
     }
 });
+
 
 /*
 

--- a/src/js/server/login.js
+++ b/src/js/server/login.js
@@ -13,14 +13,14 @@ require("./lib/password");
 
 fluid.registerNamespace("gpii.express.user.login");
 
-gpii.express.user.login.post.handler.verifyPassword = function (that, utils, request, response) {
+gpii.express.user.login.post.handler.verifyPassword = function (that, utils, request) {
     utils.unlockUser(request.body.username, request.body.password).then(
         function (data) {
             var user = fluid.model.transformWithRules(data, that.options.rules.user);
             that.options.request.session[that.options.sessionKey] = user;
             that.sendResponse(200, { message: that.options.messages.success, user: user});
         },
-        function (err, data) {
+        function () {
             that.sendResponse(401, { isError: true, message: that.options.messages.failure});
         }
     );
@@ -43,7 +43,7 @@ fluid.defaults("gpii.express.user.login.post.handler", {
     invokers: {
         handleRequest: {
             funcName: "gpii.express.user.login.post.handler.verifyPassword",
-            args: ["{that}", "{gpii.express.user.utils}", "{that}.options.request", "{that}.options.response"]
+            args: ["{that}", "{gpii.express.user.utils}", "{that}.options.request"]
         }
     },
     components: {

--- a/src/js/server/signup.js
+++ b/src/js/server/signup.js
@@ -1,9 +1,8 @@
 /* eslint-env node */
 "use strict";
+
 var fluid  = require("infusion");
 var gpii   = fluid.registerNamespace("gpii");
-
-var request = require("request"); // TODO:  Replace this with a writable data source.
 
 require("gpii-handlebars");
 
@@ -31,7 +30,7 @@ gpii.express.user.signup.post.handler.checkForExistingUser = function (that, uti
                 that.user = data;
                 that.sendMessage();
             },
-            function (error, data) {
+            function (error) {
                 that.sendResponse(500, {isError: true, message: error});
             }
         );

--- a/src/js/server/signup.js
+++ b/src/js/server/signup.js
@@ -19,48 +19,22 @@ gpii.express.user.signup.post.handler.lookupExistingUser = function (that) {
     that.reader.get(that.options.request.body).then(that.checkForExistingUser);
 };
 
-gpii.express.user.signup.post.handler.checkForExistingUser = function (that, response) {
+gpii.express.user.signup.post.handler.checkForExistingUser = function (that, utils, response) {
     if (response && response.username) {
         that.sendResponse(403, { isError: true, message: "A user with this email or username already exists."});
     }
     else {
-        // Encode the user's password
-        var salt        = gpii.express.user.password.generateSalt(that.options.saltLength);
-        var derived_key = gpii.express.user.password.encode(that.options.request.body.password, salt);
-        var code        = gpii.express.user.password.generateSalt(that.options.verifyCodeLength);
-
-        // Our rules will set the defaults and pull approved values from the original submission.
-        var combinedRecord                   = fluid.model.transformWithRules(that.options.request.body, that.options.rules.write);
-
-        // Set the "name" to the username for backward compatibility with CouchDB
-        combinedRecord.salt                  = salt;
-        combinedRecord.derived_key           = derived_key;
-        combinedRecord[that.options.codeKey] = code;
-
-        // Set the ID to match the CouchDB conventions, for backward compatibility
-        combinedRecord._id = "org.couch.db.user:" + combinedRecord.username;
-
-        // Save the record for later use in rendering the outgoing email
-        that.user = combinedRecord;
-
-        // Write the record to couch.  TODO: Migrate this to a writable dataSource.
-        var writeOptions = {
-            url:    that.options.urls.write,
-            method: "POST",
-            json:   true,
-            body:   combinedRecord
-        };
-        request(writeOptions, function (error, response, body) {
-            if (error) {
+        var body = that.options.request.body;
+        utils.createNewUser(body).then(
+            function (data) {
+                // Save the record for later use in rendering the outgoing email
+                that.user = data;
+                that.sendMessage();
+            },
+            function (error, data) {
                 that.sendResponse(500, {isError: true, message: error});
             }
-            else if ([200, 201].indexOf(response.statusCode) === -1) {
-                that.sendResponse(response.statusCode, { isError: true, message: body});
-            }
-            else {
-                that.sendMessage();
-            }
-        });
+        );
     }
 };
 
@@ -77,17 +51,6 @@ fluid.defaults("gpii.express.user.signup.post.handler", {
         error:   "A verification code could not be sent.  Contact an administrator."
     },
     rules: {
-        // Only let the user supply a very particular set of fields.
-        write: {
-            "name":          "username", // Default rules are designed to cater to CouchDB  and express-couchUser conventions, but can be overriden.
-            "username":      "username",
-            "email":         "email",
-            roles:           { literalValue: []},
-            type:            { literalValue: "user"},
-            password_scheme: { literalValue: "pbkdf2"},
-            iterations:      { literalValue: 10},
-            verified:        { literalValue: false}
-        },
         mailOptions: {
             to: "user.email",
             subject: { literalValue: "Please verify your account..."}
@@ -108,7 +71,7 @@ fluid.defaults("gpii.express.user.signup.post.handler", {
         },
         "checkForExistingUser": {
             funcName: "gpii.express.user.signup.post.handler.checkForExistingUser",
-            args:     ["{that}", "{arguments}.0"]
+            args:     ["{that}", "{gpii.express.user.utils}", "{arguments}.0"]
         }
     },
     components: {

--- a/src/js/server/utils.js
+++ b/src/js/server/utils.js
@@ -1,0 +1,140 @@
+/*
+
+    Utilities methods for performing user operations. These utilities should 
+    be usable from both http endpoints, and any other locations that can
+    consume promise based API's. 
+
+    Utilities are included for:
+    - Creating new user accounts
+    - Unlocking user accounts with a username/email and password.
+
+ */
+/* eslint-env node */
+"use strict";
+var fluid = require("infusion");
+var request = require("request"); // TODO:  Replace this with a writable data source.
+
+var gpii = fluid.registerNamespace("gpii");
+fluid.registerNamespace("gpii.express.user.utils");
+
+fluid.defaults("gpii.express.user.utils", {
+    gradeNames: ["fluid.component"],
+    invokers: {
+        createNewUser: {
+            funcName: "gpii.express.user.utils.createNewUser",
+            args: ["{that}", "{arguments}.0"] // options
+        },
+        unlockUser: {
+            funcName: "gpii.express.user.utils.unlockUser",
+            args: ["{that}", "{arguments}.0", "{arguments}.1"] // username, password
+        }
+    },
+    byUsernameOrEmailUrl:    {
+        expander: {
+            funcName: "fluid.stringTemplate",
+            args:     [ "%userDbUrl/_design/lookup/_view/byUsernameOrEmail?key=\"%username\"", "{that}.options.couch"]
+        }
+    },
+    writeUrl: "{that}.options.couch.userDbUrl",
+    saltLength:       32,
+    verifyCodeLength: 16,
+    codeKey:          "verification_code",  // Must match the value in gpii.express.user.verify
+    rules: {
+        createUserWrite: {
+            "name":          "username", // Default rules are designed to cater to CouchDB  and express-couchUser conventions, but can be overriden.
+            "username":      "username",
+            "email":         "email",
+            roles:           { literalValue: []},
+            type:            { literalValue: "user"},
+            password_scheme: { literalValue: "pbkdf2"},
+            iterations:      { literalValue: 10},
+            verified:        { literalValue: false}
+        }
+    },
+    components: {
+        byUsernameOrEmailReader: {
+            // TODO:  Replace with the new "asymmetric" dataSource once that code has been reviewed
+            type: "gpii.express.user.couchdb.read",
+            options: {
+                url: "{gpii.express.user.utils}.options.byUsernameOrEmailUrl",
+                rules: {
+                    read: {
+                        "":         "rows.0.value",
+                        "username": "rows.0.value.name"
+                    }
+                },
+                termMap: { username: "%username"}
+            }
+        }
+    }
+});
+
+gpii.express.user.utils.createNewUser = function (that, userData) {
+    // Encode the user's password
+    var salt        = gpii.express.user.password.generateSalt(that.options.saltLength);
+    var derived_key = gpii.express.user.password.encode(userData.password, salt);
+    var code        = gpii.express.user.password.generateSalt(that.options.verifyCodeLength);
+
+    // Our rules will set the defaults and pull approved values from the original submission.
+    var combinedRecord                   = fluid.model.transformWithRules(userData, that.options.rules.createUserWrite);
+
+    // Set the "name" to the username for backward compatibility with CouchDB
+    combinedRecord.salt                  = salt;
+    combinedRecord.derived_key           = derived_key;
+    combinedRecord[that.options.codeKey] = code;
+
+    // Set the ID to match the CouchDB conventions, for backward compatibility
+    combinedRecord._id = "org.couch.db.user:" + combinedRecord.username;
+
+    // Write the record to couch.  TODO: Migrate this to a writable dataSource.
+    var writeOptions = {
+        url:    that.options.writeUrl,
+        method: "POST",
+        json:   true,
+        body:   combinedRecord
+    };
+    var promiseTogo = fluid.promise();
+    request(writeOptions, function (error, response, body) {
+        if (error) {
+            promiseTogo.reject({isError: true, message: error});
+        }
+        else if ([200, 201].indexOf(response.statusCode) === -1) {
+            promiseTogo.reject({ isError: true, message: body});
+        }
+        else {
+            promiseTogo.resolve(combinedRecord);
+        }
+    });
+    return promiseTogo;
+};
+
+gpii.express.user.utils.verifyPassword = function (userRecord, password) {
+    var encodedPassword = gpii.express.user.password.encode(password, 
+        userRecord.salt, userRecord.iterations, userRecord.keyLength, userRecord.digest);
+    return encodedPassword === userRecord.derived_key;
+};
+
+gpii.express.user.utils.unlockUser = function (that, username, password) {
+    var promiseTogo = fluid.promise();
+    that.byUsernameOrEmailReader.get({username: username}).then(
+        function (body) {
+            if (body.username) {
+                var user = body;
+                var encodedPassword = gpii.express.user.password.encode(password, user.salt, user.iterations, user.keyLength, user.digest);
+                if (encodedPassword === user.derived_key) {
+                    promiseTogo.resolve(user);     
+                }
+                else {
+                    promiseTogo.reject({isError: true, message: "Bad username/password"});
+                }
+            }
+            else {
+                promiseTogo.reject({isError: true, message: "Bad username/password"});
+            }
+        },
+        function (error, data) {
+            promiseTogo.reject({isError: true, message: "Bad username/password"});
+        }
+    );
+    return promiseTogo;
+};

--- a/src/js/server/utils.js
+++ b/src/js/server/utils.js
@@ -1,8 +1,8 @@
 /*
 
-    Utilities methods for performing user operations. These utilities should 
+    Utilities methods for performing user operations. These utilities should
     be usable from both http endpoints, and any other locations that can
-    consume promise based API's. 
+    consume promise based API's.
 
     Utilities are included for:
     - Creating new user accounts
@@ -109,7 +109,7 @@ gpii.express.user.utils.createNewUser = function (that, userData) {
 };
 
 gpii.express.user.utils.verifyPassword = function (userRecord, password) {
-    var encodedPassword = gpii.express.user.password.encode(password, 
+    var encodedPassword = gpii.express.user.password.encode(password,
         userRecord.salt, userRecord.iterations, userRecord.keyLength, userRecord.digest);
     return encodedPassword === userRecord.derived_key;
 };
@@ -122,7 +122,7 @@ gpii.express.user.utils.unlockUser = function (that, username, password) {
                 var user = body;
                 var encodedPassword = gpii.express.user.password.encode(password, user.salt, user.iterations, user.keyLength, user.digest);
                 if (encodedPassword === user.derived_key) {
-                    promiseTogo.resolve(user);     
+                    promiseTogo.resolve(user);
                 }
                 else {
                     promiseTogo.reject({isError: true, message: "Bad username/password"});
@@ -132,7 +132,7 @@ gpii.express.user.utils.unlockUser = function (that, username, password) {
                 promiseTogo.reject({isError: true, message: "Bad username/password"});
             }
         },
-        function (error, data) {
+        function () {
             promiseTogo.reject({isError: true, message: "Bad username/password"});
         }
     );

--- a/src/js/server/utils.js
+++ b/src/js/server/utils.js
@@ -90,7 +90,7 @@ fluid.defaults("gpii.express.user.utils", {
  * @param {String} userData.username - New users username
  * @param {String} userData.email - New users email
  * @param {String} userData.password - Password for new account
- * @return {Promise} Promise container either the new Couch Record for
+ * @return {Promise} Promise containing either the new CouchDB record for
  * the account or an `error` property and message.
  */
 gpii.express.user.utils.createNewUser = function (that, userData) {
@@ -138,7 +138,7 @@ gpii.express.user.utils.createNewUser = function (that, userData) {
  * Given an instance of our standard couch `userRecord`, and the clear text
  * `password`, check to see if the password is valid for for the user.
  *
- * @param {Object} userRecord - Our standard internal user object stored in Couch.
+ * @param {Object} userRecord - Our standard internal user object stored in CouchDB.
  * @param {String} password - Password to use to login/unlock user.
  * @return {Boolean} - True if this is the correct password, otherwise false.
  */
@@ -153,13 +153,13 @@ gpii.express.user.utils.verifyPassword = function (userRecord, password) {
  *
  * Attempts to look up username using the current CouchDB view. (At the time
  * of writing either username or email). And unlock their account using `password`.
- * If the username and password match, the Couch userData record will be returned.
+ * If the username and password match, the CouchDB `userData` record will be returned.
  * Otherwise a standard error Object is returned.
  *
  * @param {gpii.express.user.utils} that - Utils component.
  * @param {String} username - Username to use for record lookup.
  * @param {String} password - Clear text password to validate record with.
- * @return {Object} The userData record if the password is correct, otherwise
+ * @return {Object} The `userData` record if the password is correct, otherwise
  * an `isError` Object.
  */
 gpii.express.user.utils.unlockUser = function (that, username, password) {
@@ -180,8 +180,8 @@ gpii.express.user.utils.unlockUser = function (that, username, password) {
                 promiseTogo.reject({isError: true, message: "Bad username/password"});
             }
         },
-        function () {
-            promiseTogo.reject({isError: true, message: "Bad username/password"});
+        function (err) {
+            promiseTogo.reject({isError: true, message: "Bad username/password" + JSON.stringify(err)});
         }
     );
     return promiseTogo;

--- a/src/js/server/utils.js
+++ b/src/js/server/utils.js
@@ -90,8 +90,8 @@ fluid.defaults("gpii.express.user.utils", {
  * @param {String} userData.username - New users username
  * @param {String} userData.email - New users email
  * @param {String} userData.password - Password for new account
- * @return {Promise} Promise containing either the new CouchDB record for
- * the account or an `error` property and message.
+ * @return {fluid.promise} - Promise resolving with the new CouchDB record for
+ * the account or rejecting with an `error` property and message.
  */
 gpii.express.user.utils.createNewUser = function (that, userData) {
     // Encode the user's password
@@ -159,8 +159,8 @@ gpii.express.user.utils.verifyPassword = function (userRecord, password) {
  * @param {gpii.express.user.utils} that - Utils component.
  * @param {String} username - Username to use for record lookup.
  * @param {String} password - Clear text password to validate record with.
- * @return {Object} The `userData` record if the password is correct, otherwise
- * an `isError` Object.
+ * @return {fluid.promise} - Promise resolving with a `userData` record if the password is correct, otherwise
+ * rejecting with an `isError` Object.
  */
 gpii.express.user.utils.unlockUser = function (that, username, password) {
     var promiseTogo = fluid.promise();

--- a/tests/js/server/index.js
+++ b/tests/js/server/index.js
@@ -8,3 +8,4 @@ require("./loginRequired-tests");
 require("./mailer-tests.js");
 require("./password-function-tests.js");
 require("./signup-tests.js");
+require("./utils-tests.js");

--- a/tests/js/server/utils-tests.js
+++ b/tests/js/server/utils-tests.js
@@ -1,0 +1,81 @@
+/*
+
+    Tests for the gpii.express.user.utils component.
+
+ */
+/* eslint-env node */
+"use strict";
+
+var fluid  = require("infusion");
+fluid.logObjectRenderChars = 4096;
+
+var gpii   = fluid.registerNamespace("gpii");
+var jqUnit = require("node-jqunit");
+
+require("../lib/");
+require("../../../src/js/server/lib/datasource");
+
+require("gpii-pouchdb");
+gpii.pouch.loadTestingSupport();
+
+fluid.registerNamespace("gpii.express.user.utils.tests");
+
+fluid.defaults("gpii.express.user.utils.tests.caseHolder", {
+    gradeNames: ["fluid.test.testCaseHolder"],
+    modules: [ {
+        name: "Utils component tests",
+        tests: [{
+            expect: 2,
+            name: "Unlock username/password",
+            sequence: [{
+                funcName: "gpii.express.user.utils.tests.unlockUsernamePassword",
+                args: ["{gpii.express.user.utils}"]
+            }]
+        }]
+    }]
+});
+
+gpii.express.user.utils.tests.unlockUsernamePassword = function (utils) {
+    jqUnit.assert("Ok");
+    // jqUnit.fail("Ok 2");
+    var prom = utils.unlockUser("existing", "password");
+    prom.then(function (data) {
+        jqUnit.assertEquals("Check verified username", "username", data.username);
+    }, function (err) {
+        jqUnit.fail("Error unlocking user: " + JSON.stringify(err));
+    });
+};
+
+fluid.defaults("gpii.express.user.utils.tests.pouchMixin", {
+    gradeNames: ["fluid.component"],
+    databases: {
+        myEmptyDb: {},
+        myFullDb: {
+            data: "%gpii-express-user/tests/data/users.json"
+        }
+    }
+});
+
+fluid.defaults("gpii.express.user.utils.tests", {
+    gradeNames: ["gpii.test.pouch.environment"],
+    port: 5001,
+    harnessGrades: ["gpii.express.user.utils.tests.pouchMixin"],
+    components: {
+        testCaseHolder: {
+            type: "gpii.express.user.utils.tests.caseHolder"
+        },
+        utils: {
+            type: "gpii.express.user.utils",
+            options: {
+                couch:  {
+                    // port: "{testEnvironment}.options.pouchPort",
+                    port: "5001",
+                    userDbName: "users",
+                    userDbUrl: "http://127.0.0.1:5001/users"
+                }
+            }
+        }
+    }
+});
+
+fluid.test.runTests("gpii.express.user.utils.tests");

--- a/tests/js/server/utils-tests.js
+++ b/tests/js/server/utils-tests.js
@@ -16,7 +16,7 @@ var jqUnit       = require("node-jqunit");
 
 fluid.registerNamespace("gpii.tests.express.user.utils.caseHolder");
 
-gpii.tests.express.user.utils.createUser = function (utils, sequenceDelay) {
+gpii.tests.express.user.utils.createUser = function (utils) {
     var prom = utils.createNewUser({
         username: "myFirstUser",
         password: "this is a password",
@@ -27,55 +27,36 @@ gpii.tests.express.user.utils.createUser = function (utils, sequenceDelay) {
         jqUnit.assertEquals("Email", "myFirstUser@gpii.net", data.email);
         jqUnit.assertEquals("Username", "myFirstUser", data.username);
         jqUnit.assertTrue("Unlock the password", gpii.express.user.utils.verifyPassword(data, "this is a password"));
-        sequenceDelay.events.onComplete.fire();
     }, function (err) {
         jqUnit.fail("Unable to create user with error: " + err);
-        sequenceDelay.events.onComplete.fire();
     });
+    return prom;
 };
 
-gpii.tests.express.user.utils.unlockUsernamePassword = function (utils, sequenceDelay) {
+gpii.tests.express.user.utils.unlockUsernamePassword = function (utils) {
     var prom = utils.unlockUser("existing", "password");
     prom.then(function (data) {
         jqUnit.assertEquals("Check verified username", "existing", data.username);
-        sequenceDelay.events.onComplete.fire();
     }, function (err) {
         jqUnit.fail("Error unlocking user: " + JSON.stringify(err));
-        sequenceDelay.events.onComplete.fire();
     });
+    return prom;
 };
 
-gpii.tests.express.user.utils.incorrectUsernamePassword = function (utils, sequenceDelay) {
+gpii.tests.express.user.utils.incorrectUsernamePassword = function (utils) {
     var prom = utils.unlockUser("not-existing", "password");
     prom.then(function () {
         jqUnit.fail("This user shouldn't have unlocked with the supplied credentials.");
-        sequenceDelay.events.onComplete.fire();
     }, function () {
         jqUnit.assert("Succeeded in not unlocking with incorrect credentials");
-        sequenceDelay.events.onComplete.fire();
     });
+    return prom;
 };
-
-/**
- * Simple component with an onComplete event to use as a delay in the tests sequences
- * when executing promises or other logic in a custom test method.
- */
-fluid.defaults("gpii.tests.express.user.sequenceDelay", {
-    gradeNames: ["fluid.component"],
-    events: {
-        onComplete: null
-    }
-});
 
 // Each test has a request instance of `kettle.test.request.http` or `kettle.test.request.httpCookie`,
 // and a test module that wires the request to the listener that handles its results.
 fluid.defaults("gpii.tests.express.user.utils.caseHolder", {
     gradeNames: ["gpii.test.webdriver.caseHolder"],
-    components: {
-        sequenceDelay: {
-            type: "gpii.tests.express.user.sequenceDelay"
-        }
-    },
     rawModules: [
         {
             name: "Testing login functions...",
@@ -85,13 +66,10 @@ fluid.defaults("gpii.tests.express.user.utils.caseHolder", {
                     type: "test",
                     sequence: [
                         {
-                            funcName: "gpii.tests.express.user.utils.createUser",
-                            args: ["{gpii.express.user.utils}", "{sequenceDelay}"]
-                        },
-                        {
-                            listener: "fluid.log",
-                            event: "{sequenceDelay}.events.onComplete",
-                            args: ["Finished create user test"]
+                            task: "gpii.tests.express.user.utils.createUser",
+                            args: ["{gpii.express.user.utils}"],
+                            resolve: "jqUnit.assert",
+                            resolveArgs: ["Successfully created User"]
                         }
                     ]
                 },
@@ -100,13 +78,10 @@ fluid.defaults("gpii.tests.express.user.utils.caseHolder", {
                     type: "test",
                     sequence: [
                         {
-                            funcName: "gpii.tests.express.user.utils.unlockUsernamePassword",
-                            args: ["{gpii.express.user.utils}", "{sequenceDelay}"]
-                        },
-                        {
-                            listener: "fluid.log",
-                            event: "{sequenceDelay}.events.onComplete",
-                            args: ["Finished unlockUsernamePassword test"]
+                            task: "gpii.tests.express.user.utils.unlockUsernamePassword",
+                            args: ["{gpii.express.user.utils}"],
+                            resolve: "jqUnit.assert",
+                            resolveArgs: ["Successfully unlocked User"]
                         }
                     ]
                 },
@@ -115,13 +90,10 @@ fluid.defaults("gpii.tests.express.user.utils.caseHolder", {
                     type: "test",
                     sequence: [
                         {
-                            funcName: "gpii.tests.express.user.utils.incorrectUsernamePassword",
-                            args: ["{gpii.express.user.utils}", "{sequenceDelay}"]
-                        },
-                        {
-                            listener: "fluid.log",
-                            event: "{sequenceDelay}.events.onComplete",
-                            args: ["Finished incorrect credentials test"]
+                            task: "gpii.tests.express.user.utils.incorrectUsernamePassword",
+                            args: ["{gpii.express.user.utils}"],
+                            reject: "jqUnit.assert",
+                            rejectArgs: ["Failed to open with bad credentials"]
                         }
                     ]
                 }

--- a/tests/js/server/utils-tests.js
+++ b/tests/js/server/utils-tests.js
@@ -16,6 +16,24 @@ var jqUnit       = require("node-jqunit");
 
 fluid.registerNamespace("gpii.tests.express.user.utils.caseHolder");
 
+gpii.tests.express.user.utils.createUser = function (utils, sequenceDelay) {
+    var prom = utils.createNewUser({
+        username: "myFirstUser",
+        password: "this is a password",
+        email: "myFirstUser@gpii.net"
+    });
+    prom.then(function (data) {
+        jqUnit.assertEquals("Generated Couch ID", "org.couch.db.user:myFirstUser", data._id);
+        jqUnit.assertEquals("Email", "myFirstUser@gpii.net", data.email);
+        jqUnit.assertEquals("Username", "myFirstUser", data.username);
+        jqUnit.assertTrue("Unlock the password", gpii.express.user.utils.verifyPassword(data, "this is a password"));
+        sequenceDelay.events.onComplete.fire();
+    }, function (err) {
+        jqUnit.fail("Unable to create user with error: " + err);
+        sequenceDelay.events.onComplete.fire();
+    });
+};
+
 gpii.tests.express.user.utils.unlockUsernamePassword = function (utils, sequenceDelay) {
     var prom = utils.unlockUser("existing", "password");
     prom.then(function (data) {
@@ -23,6 +41,17 @@ gpii.tests.express.user.utils.unlockUsernamePassword = function (utils, sequence
         sequenceDelay.events.onComplete.fire();
     }, function (err) {
         jqUnit.fail("Error unlocking user: " + JSON.stringify(err));
+        sequenceDelay.events.onComplete.fire();
+    });
+};
+
+gpii.tests.express.user.utils.incorrectUsernamePassword = function (utils, sequenceDelay) {
+    var prom = utils.unlockUser("not-existing", "password");
+    prom.then(function () {
+        jqUnit.fail("This user shouldn't have unlocked with the supplied credentials.");
+        sequenceDelay.events.onComplete.fire();
+    }, function () {
+        jqUnit.assert("Succeeded in not unlocking with incorrect credentials");
         sequenceDelay.events.onComplete.fire();
     });
 };
@@ -38,7 +67,8 @@ fluid.defaults("gpii.tests.express.user.sequenceDelay", {
     }
 });
 
-// Each test has a request instance of `kettle.test.request.http` or `kettle.test.request.httpCookie`, and a test module that wires the request to the listener that handles its results.
+// Each test has a request instance of `kettle.test.request.http` or `kettle.test.request.httpCookie`,
+// and a test module that wires the request to the listener that handles its results.
 fluid.defaults("gpii.tests.express.user.utils.caseHolder", {
     gradeNames: ["gpii.test.webdriver.caseHolder"],
     components: {
@@ -51,7 +81,22 @@ fluid.defaults("gpii.tests.express.user.utils.caseHolder", {
             name: "Testing login functions...",
             tests: [
                 {
-                    name: "Testing logging in with an unverified account...",
+                    name: "Create a new user and verify their data.",
+                    type: "test",
+                    sequence: [
+                        {
+                            funcName: "gpii.tests.express.user.utils.createUser",
+                            args: ["{gpii.express.user.utils}", "{sequenceDelay}"]
+                        },
+                        {
+                            listener: "fluid.log",
+                            event: "{sequenceDelay}.events.onComplete",
+                            args: ["Finished create user test"]
+                        }
+                    ]
+                },
+                {
+                    name: "Testing unlocking a user with correct credentials.",
                     type: "test",
                     sequence: [
                         {
@@ -64,7 +109,23 @@ fluid.defaults("gpii.tests.express.user.utils.caseHolder", {
                             args: ["Finished unlockUsernamePassword test"]
                         }
                     ]
+                },
+                {
+                    name: "Testing not unlocking a user with incorrect credentials.",
+                    type: "test",
+                    sequence: [
+                        {
+                            funcName: "gpii.tests.express.user.utils.incorrectUsernamePassword",
+                            args: ["{gpii.express.user.utils}", "{sequenceDelay}"]
+                        },
+                        {
+                            listener: "fluid.log",
+                            event: "{sequenceDelay}.events.onComplete",
+                            args: ["Finished incorrect credentials test"]
+                        }
+                    ]
                 }
+
             ]
         }
     ]

--- a/tests/js/server/utils-tests.js
+++ b/tests/js/server/utils-tests.js
@@ -15,51 +15,46 @@ var jqUnit = require("node-jqunit");
 require("../lib/");
 require("../../../src/js/server/lib/datasource");
 
-require("gpii-pouchdb");
-gpii.pouch.loadTestingSupport();
-
 fluid.registerNamespace("gpii.express.user.utils.tests");
 
 fluid.defaults("gpii.express.user.utils.tests.caseHolder", {
-    gradeNames: ["fluid.test.testCaseHolder"],
-    modules: [ {
-        name: "Utils component tests",
-        tests: [{
-            expect: 2,
-            name: "Unlock username/password",
-            sequence: [{
-                funcName: "gpii.express.user.utils.tests.unlockUsernamePassword",
-                args: ["{gpii.express.user.utils}"]
-            }]
-        }]
-    }]
+    gradeNames: ["gpii.test.webdriver.caseHolder"],
+    rawModules: [
+        {
+            name: "Utils component tests",
+            tests: [
+                {
+                    name: "Unlock username/password",
+                    type: "test",
+                    expect: 2,
+                    sequence: [
+                        {
+                            funcName: "gpii.express.user.utils.tests.unlockUsernamePassword",
+                            args: ["{gpii.express.user.utils}"]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
 });
 
 gpii.express.user.utils.tests.unlockUsernamePassword = function (utils) {
     jqUnit.assert("Ok");
-    // jqUnit.fail("Ok 2");
+    jqUnit.stop();
     var prom = utils.unlockUser("existing", "password");
     prom.then(function (data) {
-        jqUnit.assertEquals("Check verified username", "username", data.username);
+        jqUnit.start();
+        jqUnit.assertEquals("Check verified username", "existing", data.username);
     }, function (err) {
+        jqUnit.start();
         jqUnit.fail("Error unlocking user: " + JSON.stringify(err));
     });
 };
 
-fluid.defaults("gpii.express.user.utils.tests.pouchMixin", {
-    gradeNames: ["fluid.component"],
-    databases: {
-        myEmptyDb: {},
-        myFullDb: {
-            data: "%gpii-express-user/tests/data/users.json"
-        }
-    }
-});
-
 fluid.defaults("gpii.express.user.utils.tests", {
-    gradeNames: ["gpii.test.pouch.environment"],
-    port: 5001,
-    harnessGrades: ["gpii.express.user.utils.tests.pouchMixin"],
+    gradeNames: ["gpii.test.express.user.environment"],
+    pouchPort: 8764,
     components: {
         testCaseHolder: {
             type: "gpii.express.user.utils.tests.caseHolder"
@@ -68,10 +63,7 @@ fluid.defaults("gpii.express.user.utils.tests", {
             type: "gpii.express.user.utils",
             options: {
                 couch:  {
-                    // port: "{testEnvironment}.options.pouchPort",
-                    port: "5001",
-                    userDbName: "users",
-                    userDbUrl: "http://127.0.0.1:5001/users"
+                    userDbUrl: "http://127.0.0.1:8764/users"
                 }
             }
         }


### PR DESCRIPTION
@the-t-in-rtf Re-opening this branch from the work and comments in this PR:

https://github.com/the-t-in-rtf/gpii-express-user/pull/7

I'm wondering if you could run the server tests and take a look at my `utils-tests.js`. I'm having a hard time getting the pouchdb test harness to accept connections. I can't figure out if it's actually starting up or not, but it appears to be an instantiated component when I look in the debugger.  My tests can make a network connection to it.  I've tried a number of different ports, as I've found sometimes node complains when making connections to localhost for certain port ranges on higher ranges.

```
16:40:58.217:  jq: FAIL: Module "Utils component tests" Test name "Unlock username/password" - Message: Error unlo
cking user: {"isError":true,"message":"Bad username/password{\"code\":\"ECONNREFUSED\",\"errno\":\"ECONNREFUSED\",
\"syscall\":\"connect\",\"address\":\"127.0.0.1\",\"port\":5001,\"isError\":true}"}
16:40:58.218:  jq: Source:     at pok (/Users/sgithens/raisingthefloor/gpii-express-user/node_modules/infusion/tes
ts/test-core/jqUnit/js/jqUnit.js:112:15)
    at Object.fail (/Users/sgithens/raisingthefloor/gpii-express-user/node_modules/infusion/tests/test-core/jqUnit
/js/jqUnit.js:129:13)
    at Array.<anonymous> (/Users/sgithens/raisingthefloor/gpii-express-user/tests/js/server/utils-tests.js:45:16)
    at Object.that.complete (/Users/sgithens/raisingthefloor/gpii-express-user/node_modules/infusion/src/framework
/core/js/FluidPromises.js:70:25)
[SNIP]
```